### PR TITLE
Pin mustache to 0.99.8

### DIFF
--- a/pleaserun.gemspec
+++ b/pleaserun.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "clamp"
   spec.add_dependency "cabin"
   spec.add_dependency "stud"
-  spec.add_dependency "mustache"
+  spec.add_dependency "mustache", ">= 0.99.8"
   spec.add_dependency "insist"
   spec.add_dependency "ohai", "~> 6.20" # used for host detection
 


### PR DESCRIPTION
This is the last supported version of mustache before ruby 2.0 support -
the difference between the two being inconsequential.

The bundler file pins at 0.99.5 - I can also make that the case in this.